### PR TITLE
feat: Import EEPROM + fix DCS tone encoding for nicFW H3

### DIFF
--- a/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/MainActivity.kt
+++ b/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/MainActivity.kt
@@ -218,6 +218,84 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // ─── EEPROM import ────────────────────────────────────────────────────────
+    /**
+     * Launches the system file picker for a raw EEPROM dump file, reads the bytes on the
+     * IO dispatcher, then delegates to [importEepromFromFile] to parse and load channels.
+     */
+    private val eepromPickerLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@registerForActivityResult
+        lifecycleScope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+            if (bytes == null || bytes.isEmpty()) {
+                Toast.makeText(this@MainActivity, "Could not read file", Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            importEepromFromFile(bytes)
+        }
+    }
+
+    /**
+     * Parses channels from raw EEPROM [bytes] using the selected radio's CHIRP driver —
+     * exactly like a live radio download but without a USB/BLE connection. Populates
+     * [EepromHolder] and refreshes the channel list on success.
+     */
+    private fun importEepromFromFile(bytes: ByteArray) {
+        val radio = selectedRadio ?: run {
+            Toast.makeText(this, "Select a radio model first (⋮ → Select Radio Model)", Toast.LENGTH_LONG).show()
+            return
+        }
+        val b64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+        binding.progressBar.visibility = View.VISIBLE
+        binding.progressBar.isIndeterminate = true
+        binding.progressText.visibility = View.VISIBLE
+        startTransferStatusHints(downloadStatusMessages)
+        binding.btnLoad.isEnabled = false
+        binding.btnSave.isEnabled = false
+        lifecycleScope.launch {
+            try {
+                EepromHolder.selectedRadio = radio
+                val result = ChirpBridge.loadFromEeprom(radio, b64)
+                val eepromBytes = if (result.eepromBase64 != null) {
+                    Base64.decode(result.eepromBase64, Base64.NO_WRAP)
+                } else {
+                    ByteArray(0)
+                }
+                eeprom = eepromBytes
+                EepromHolder.eeprom = eepromBytes
+                EepromHolder.channels = result.channels.toMutableList()
+                EepromHolder.extraParamNames = result.channels
+                    .firstOrNull { it.extra.isNotEmpty() }
+                    ?.extra?.keys?.toList() ?: emptyList()
+                EepromHolder.channelExtraSchema = ChirpBridge.getChannelExtraSchema(radio, result.eepromBase64)
+                refreshChannelList()
+                runOnUiThread {
+                    hideRadioTransferProgress()
+                    updateConnectionUi()
+                    invalidateOptionsMenu()
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Imported ${result.channels.size} channels from EEPROM file.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            } catch (e: Exception) {
+                runOnUiThread {
+                    hideRadioTransferProgress()
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Import failed: ${e.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }
+    }
+
     /**
      * Validates [csvText] with [ChirpCsvImporter] and, if valid, launches
      * [ChirpImportActivity] with the full preview and group-assignment UI.
@@ -593,6 +671,7 @@ class MainActivity : AppCompatActivity() {
         menu.findItem(R.id.action_radio_settings)?.isEnabled          =
             EepromHolder.radioFeatures.hasSettings && selectedRadio != null &&
             (activePort != null || hasCloneEeprom)
+        menu.findItem(R.id.action_import_eeprom)?.isEnabled          = selectedRadio != null
         menu.findItem(R.id.action_save_eeprom_dump)?.isEnabled        = hasCloneEeprom
         menu.findItem(R.id.action_export_csv)?.isEnabled             = hasChannels
         return super.onPrepareOptionsMenu(menu)
@@ -632,6 +711,10 @@ class MainActivity : AppCompatActivity() {
                 val p = activePort ?: ""
                 if (r != null && (p.isNotBlank() || (EepromHolder.eeprom != null && EepromHolder.eeprom!!.isNotEmpty())))
                     startActivity(RadioSettingsActivity.intent(this, r, p))
+                true
+            }
+            R.id.action_import_eeprom -> {
+                eepromPickerLauncher.launch(arrayOf("application/octet-stream", "*/*"))
                 true
             }
             R.id.action_save_eeprom_dump -> {

--- a/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/bridge/ChirpBridge.kt
+++ b/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/bridge/ChirpBridge.kt
@@ -213,6 +213,29 @@ object ChirpBridge {
         }
 
     /**
+     * Loads channels from a raw EEPROM file dump (clone-mode radios only). No radio connection
+     * is needed — the driver is instantiated directly from the provided bytes.
+     *
+     * Returns a [DownloadResult] in the same shape as [download] so the caller can populate
+     * [EepromHolder] exactly as if the data had come from a live radio download.
+     *
+     * @param radio       Selected radio model (must be clone-mode)
+     * @param eepromBase64 Base64-encoded raw EEPROM bytes read from a .img / .bin file
+     */
+    suspend fun loadFromEeprom(radio: RadioInfo, eepromBase64: String): DownloadResult =
+        withContext(Dispatchers.IO) {
+            val jsonStr = bridge.callAttr("load_from_eeprom", radio.vendor, radio.model, eepromBase64).toString()
+            val obj = org.json.JSONObject(jsonStr)
+            val arr = obj.getJSONArray("channels")
+            val channels = (0 until arr.length()).map { i ->
+                Channel.fromJson(i + 1, arr.getJSONObject(i))
+            }
+            val eepromStr = obj.optString("eeprom_base64", "")
+            val eepromBase64Out = eepromStr.takeIf { it.isNotBlank() && it != "null" }
+            DownloadResult(channels = channels, eepromBase64 = eepromBase64Out)
+        }
+
+    /**
      * Applies a single channel edit to the in-memory clone EEPROM so the raw dump
      * stays in sync with the channel list. Returns new eeprom bytes (base64 decoded).
      */

--- a/AndroidRadioDroid/app/src/main/python/chirp_bridge.py
+++ b/AndroidRadioDroid/app/src/main/python/chirp_bridge.py
@@ -176,7 +176,8 @@ def get_radio_list():
 
 
 def _memory_to_dict(mem) -> dict:
-    tmode    = getattr(mem, "tmode",  "") or ""
+    tmode      = getattr(mem, "tmode",      "") or ""
+    cross_mode = getattr(mem, "cross_mode", "") or ""
     duplex   = getattr(mem, "duplex", "") or ""
     freq     = getattr(mem, "freq",   0)  or 0
     offset   = getattr(mem, "offset", 0)  or 0
@@ -185,6 +186,27 @@ def _memory_to_dict(mem) -> dict:
     dtcs_pol = getattr(mem, "dtcs_polarity", "NN") or "NN"
     tx_pol   = dtcs_pol[0:1] if dtcs_pol else "N"
     rx_pol   = dtcs_pol[1:2] if len(dtcs_pol) > 1 else "N"
+
+    # Resolve per-side tone mode/value, handling CHIRP's "Cross" tmode.
+    # Drivers like nicFW use split_tone_decode() which sets tmode="Cross" whenever
+    # TX and RX tones differ (e.g. DTCS->DTCS repeater with different codes).
+    if tmode == "Cross":
+        _tx_type, _, _rx_type = cross_mode.partition("->")
+        tx_tone_mode = _tx_type if _tx_type in ("Tone", "DTCS") else ""
+        rx_tone_mode = _rx_type if _rx_type in ("Tone", "DTCS") else ""
+        tx_tone_val  = (getattr(mem, "rtone",   0.0) if _tx_type == "Tone"
+                        else getattr(mem, "dtcs",    0)   if _tx_type == "DTCS" else 0.0)
+        rx_tone_val  = (getattr(mem, "ctone",   0.0) if _rx_type == "Tone"
+                        else getattr(mem, "rx_dtcs", 0)   if _rx_type == "DTCS" else 0.0)
+    else:
+        tx_tone_mode = tmode if tmode in ("Tone", "TSQL", "DTCS") else ""
+        tx_tone_val  = (getattr(mem, "rtone", 0.0) if tmode in ("Tone", "TSQL")
+                        else getattr(mem, "dtcs", 0) if tmode == "DTCS" else 0.0)
+        rx_tone_mode = ("TSQL" if tmode == "TSQL" else
+                        "DTCS" if tmode == "DTCS" else "")
+        rx_tone_val  = (getattr(mem, "ctone", 0.0) if tmode == "TSQL"
+                        else getattr(mem, "dtcs", 0) if tmode == "DTCS" else 0.0)
+
     out = {
         "number":            mem.number,
         "name":              getattr(mem, "name", "") or "",
@@ -194,14 +216,11 @@ def _memory_to_dict(mem) -> dict:
         "offset":            offset,
         "power":             str(getattr(mem, "power", "1") or "1"),
         "mode":              getattr(mem, "mode", "FM") or "FM",
-        "tx_tone_mode":      tmode if tmode in ("Tone", "TSQL", "DTCS") else "",
-        "tx_tone_val":       (getattr(mem, "rtone", 0.0) if tmode in ("Tone", "TSQL")
-                              else getattr(mem, "dtcs", 0) if tmode == "DTCS" else 0.0),
+        "tx_tone_mode":      tx_tone_mode,
+        "tx_tone_val":       tx_tone_val,
         "tx_tone_polarity":  tx_pol,
-        "rx_tone_mode":      ("TSQL" if tmode == "TSQL" else
-                              "DTCS" if tmode == "DTCS" else ""),
-        "rx_tone_val":       (getattr(mem, "ctone", 0.0) if tmode == "TSQL"
-                              else getattr(mem, "dtcs", 0) if tmode == "DTCS" else 0.0),
+        "rx_tone_mode":      rx_tone_mode,
+        "rx_tone_val":       rx_tone_val,
         "rx_tone_polarity":  rx_pol,
         "empty":             getattr(mem, "empty", False),
         "skip":              getattr(mem, "skip",  "") or "",
@@ -889,6 +908,47 @@ def upload_mmap(vendor: str, model: str, port: str, baudrate: int, eeprom_base64
         radio.pipe.close()
 
 
+def load_from_eeprom(vendor: str, model: str, eeprom_base64: str) -> str:
+    """
+    Load channels from a raw EEPROM dump (clone-mode radios only). No radio connection needed.
+    Instantiates the CHIRP driver from the provided EEPROM bytes, reads channels, and returns
+    the same JSON structure as download(): {"channels": [...], "eeprom_base64": "<str>"}.
+
+    Args:
+        vendor:        Radio vendor string (e.g. "Radioddity")
+        model:         Radio model string (e.g. "TD-H3 (nicFW)")
+        eeprom_base64: Base64-encoded raw EEPROM bytes (e.g. from a saved .img file)
+
+    Raises:
+        Exception: if the driver is not clone-mode or the EEPROM cannot be parsed
+    """
+    import base64
+    import json as _json
+    _ensure_drivers()
+    from chirp import chirp_common
+    from chirp import memmap
+
+    radio_cls = _find_radio_cls(vendor, model)
+    if not issubclass(radio_cls, chirp_common.CloneModeRadio):
+        raise Exception("load_from_eeprom requires a clone-mode radio driver")
+
+    data = base64.b64decode(eeprom_base64)
+    mmap = memmap.MemoryMapBytes(bytes(data))
+    radio = radio_cls(mmap)
+
+    features = radio.get_features()
+    lo, hi = features.memory_bounds
+    channels = []
+    for n in range(lo, hi + 1):
+        try:
+            mem = radio.get_memory(n)
+            channels.append(_memory_to_dict(mem))
+        except Exception:
+            channels.append({"number": n, "empty": True})
+
+    return _json.dumps({"channels": channels, "eeprom_base64": eeprom_base64})
+
+
 def apply_channel_to_mmap(vendor: str, model: str, eeprom_base64: str, channel_json: str) -> str:
     """
     Apply a single channel edit to the in-memory EEPROM (clone-mode only).
@@ -929,6 +989,69 @@ def apply_channel_to_mmap(vendor: str, model: str, eeprom_base64: str, channel_j
     return base64.b64encode(new_raw).decode()
 
 
+def _apply_tones_to_memory(mem, ch, features):
+    """
+    Set mem.tmode / tone fields from a channel dict produced by _memory_to_dict().
+
+    Handles all CHIRP tone modes including "Cross" (e.g. DTCS->DTCS repeaters
+    where TX and RX DCS codes differ).  When the driver's valid_tmodes includes
+    "Cross", the correct cross_mode is reconstructed so a round-trip through
+    the driver is lossless.
+    """
+    tx_tmode  = ch.get("tx_tone_mode", "") or ""
+    rx_tmode  = ch.get("rx_tone_mode", "") or ""
+    tx_val    = ch.get("tx_tone_val")
+    rx_val    = ch.get("rx_tone_val")
+    tx_pol    = (ch.get("tx_tone_polarity") or "N")[:1]
+    rx_pol    = (ch.get("rx_tone_polarity") or "N")[:1]
+    valid_tmodes = getattr(features, "valid_tmodes", None)
+
+    def _supports(mode):
+        return not valid_tmodes or mode in valid_tmodes
+
+    if tx_tmode == "DTCS" and rx_tmode == "DTCS":
+        tx_code = int(tx_val or 23)
+        rx_code = int(rx_val or 23)
+        mem.dtcs_polarity = tx_pol + rx_pol
+        if tx_code == rx_code and _supports("DTCS"):
+            mem.tmode = "DTCS"
+            mem.dtcs  = tx_code
+        elif _supports("Cross"):
+            mem.tmode      = "Cross"
+            mem.cross_mode = "DTCS->DTCS"
+            mem.dtcs       = tx_code
+            mem.rx_dtcs    = rx_code
+        else:
+            # Driver doesn't support Cross — best effort: use TX code
+            mem.tmode = "DTCS"
+            mem.dtcs  = tx_code
+    elif tx_tmode == "DTCS" and _supports("Cross"):
+        # DTCS-> or DTCS->Tone
+        mem.tmode       = "Cross"
+        mem.cross_mode  = "DTCS->%s" % (rx_tmode or "")
+        mem.dtcs        = int(tx_val or 23)
+        mem.dtcs_polarity = tx_pol + rx_pol
+        if rx_tmode == "Tone":
+            mem.ctone = float(rx_val or 88.5)
+    elif rx_tmode == "DTCS" and _supports("Cross"):
+        # ->DTCS or Tone->DTCS
+        mem.tmode      = "Cross"
+        mem.cross_mode = "%s->DTCS" % (tx_tmode or "")
+        mem.rx_dtcs    = int(rx_val or 23)
+        mem.dtcs_polarity = tx_pol + rx_pol
+        if tx_tmode == "Tone":
+            mem.rtone = float(tx_val or 88.5)
+    elif tx_tmode == "TSQL":
+        mem.tmode = "TSQL"
+        mem.rtone = float(tx_val or 88.5)
+        mem.ctone = float(rx_val or 88.5)
+    elif tx_tmode == "Tone":
+        mem.tmode = "Tone"
+        mem.rtone = float(tx_val or 88.5)
+    else:
+        mem.tmode = ""
+
+
 def _channel_dict_into_memory(mem, ch, features):
     """Fill a CHIRP Memory from a channel dict (same logic as upload() loop)."""
     from chirp import chirp_common
@@ -947,25 +1070,7 @@ def _channel_dict_into_memory(mem, ch, features):
     if valid_modes and mode not in valid_modes:
         mode = "FM"
     mem.mode = mode
-    tmode = ch.get("tx_tone_mode", "") or ""
-    valid_tmodes = getattr(features, "valid_tmodes", None)
-    if valid_tmodes and tmode not in valid_tmodes:
-        tmode = ""
-    if tmode == "Tone":
-        mem.tmode = "Tone"
-        mem.rtone = float(ch.get("tx_tone_val") or 88.5)
-    elif tmode == "TSQL":
-        mem.tmode = "TSQL"
-        mem.rtone = float(ch.get("tx_tone_val") or 88.5)
-        mem.ctone = float(ch.get("rx_tone_val") or 88.5)
-    elif tmode == "DTCS":
-        mem.tmode = "DTCS"
-        mem.dtcs = int(ch.get("tx_tone_val") or 23)
-        tx_pol = (ch.get("tx_tone_polarity") or "N")[:1]
-        rx_pol = (ch.get("rx_tone_polarity") or "N")[:1]
-        mem.dtcs_polarity = tx_pol + rx_pol
-    else:
-        mem.tmode = ""
+    _apply_tones_to_memory(mem, ch, features)
     power_str = ch.get("power", "") or ""
     if power_str and features.valid_power_levels:
         matched = next(
@@ -1101,29 +1206,7 @@ def upload(vendor: str, model: str, port: str, baudrate: int, channels_json: str
             mem.mode = mode
 
             # ── Tone / CTCSS / DCS ───────────────────────────────────────────────
-            # tx_tone_mode drives mem.tmode; values mirror CHIRP's own tmode strings.
-            # Guard against tone modes the radio doesn't support.
-            tmode = ch.get("tx_tone_mode", "") or ""
-            valid_tmodes = getattr(features, "valid_tmodes", None)
-            if valid_tmodes and tmode not in valid_tmodes:
-                tmode = ""
-            if tmode == "Tone":
-                mem.tmode = "Tone"
-                mem.rtone = float(ch.get("tx_tone_val") or 88.5)
-            elif tmode == "TSQL":
-                mem.tmode = "TSQL"
-                mem.rtone = float(ch.get("tx_tone_val") or 88.5)
-                mem.ctone = float(ch.get("rx_tone_val") or 88.5)
-            elif tmode == "DTCS":
-                mem.tmode = "DTCS"
-                mem.dtcs  = int(ch.get("tx_tone_val") or 23)
-                # Polarity is stored as two chars "NN"/"NR"/"RN"/"RR" in CHIRP.
-                # tx_tone_polarity / rx_tone_polarity default to "N" (normal).
-                tx_pol = (ch.get("tx_tone_polarity") or "N")[:1]
-                rx_pol = (ch.get("rx_tone_polarity") or "N")[:1]
-                mem.dtcs_polarity = tx_pol + rx_pol
-            else:
-                mem.tmode = ""
+            _apply_tones_to_memory(mem, ch, features)
 
             # ── Power level ──────────────────────────────────────────────────────
             # CHIRP uses driver-specific PowerLevel objects.  Try to match the

--- a/AndroidRadioDroid/app/src/main/res/menu/menu_main.xml
+++ b/AndroidRadioDroid/app/src/main/res/menu/menu_main.xml
@@ -35,6 +35,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_import_eeprom"
+        android:title="Import EEPROM…"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_save_eeprom_dump"
         android:title="Save EEPROM dump…"
         app:showAsAction="never" />


### PR DESCRIPTION
## Summary
- **Import EEPROM** — new menu item above "Save EEPROM dump…" that loads a raw `.img`/`.bin` EEPROM file exactly like a live radio download (no USB/BLE connection needed); populates the full channel list, EEPROM in memory, channel extra schema, and Radio Settings
- **DCS Cross-mode fix** — channels with `tmode="Cross"` (e.g. DTCS->DTCS repeaters where TX ≠ RX code) were silently dropped in `_memory_to_dict()`; added `_apply_tones_to_memory()` helper that correctly handles all Cross combinations for both download and upload paths
- **nicFW H3 DCS binary↔octal fix** — the driver's `_decode_tone`/`_encode_tone` returned raw binary DCS values (e.g. 85) instead of CHIRP's octal-encoded format (e.g. 125); this caused channels like Oxford Boro and Jennersville to appear empty because CHIRP's `Memory` validation rejected code 85; the same fix was pushed to `jnyer27/NICFW-H3-25-CHIRP-ADAPTER`

## Test plan
- [ ] Import EEPROM from `TD-H3 EEPROM dump 20260321_000857` — channels should load with no radio connected
- [ ] Channels 49 (Oxford Boro, 462.675 MHz, D125N) and 56 (Jennersville, 462.725 MHz, D125N) should appear populated, not empty
- [ ] Save EEPROM dump still works after import
- [ ] Radio Settings accessible after import (no connection needed)
- [ ] Import CHIRP CSV and Export CHIRP CSV unaffected
- [ ] Live download from radio still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)