### PR TITLE
Fix #10 NICFW group labels + #11 radio-spec row on narrow/fold

### DIFF
--- a/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/ChannelAdapter.kt
+++ b/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/ChannelAdapter.kt
@@ -5,7 +5,9 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.view.ViewTreeObserver
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -40,6 +42,9 @@ class ChannelAdapter(
     companion object {
         /** When groups summary is shown from [Channel.group1]–[Channel.group4], hide matching extra rows. */
         private val GROUP_EXTRA_KEYS = setOf("group1", "group2", "group3", "group4")
+
+        /** Avoid infinite repost when width stays 0 (foldables / narrow passes). */
+        private const val MAX_ZERO_WIDTH_SPEC_RETRIES = 5
     }
 
     // ── Selection state ───────────────────────────────────────────────────────
@@ -157,6 +162,9 @@ class ChannelAdapter(
         private var pendingRadioSpecItems: List<String>? = null
         private var lastSpecCols: Int = -1
         private var lastSpecItems: List<String>? = null
+        /** Incremented each [bind]; stale [post] runnables bail when this mismatches. */
+        private var radioSpecLayoutToken: Long = 0L
+        private var zeroWidthSpecRetries: Int = 0
 
         init {
             channelRadioSpecColumns.addOnLayoutChangeListener { _, left, _, right, _, oldLeft, _, oldRight, _ ->
@@ -165,8 +173,9 @@ class ChannelAdapter(
                 if (w > 0 && w != ow) {
                     val pending = pendingRadioSpecItems
                     if (pending != null && pending.isNotEmpty()) {
+                        val token = radioSpecLayoutToken
                         lastSpecCols = -1
-                        applyRadioSpecColumns(pending)
+                        applyRadioSpecColumns(pending, token)
                     }
                 }
             }
@@ -177,6 +186,8 @@ class ChannelAdapter(
             channelNumber.text = card.context.getString(R.string.channel_number, channel.number)
 
             if (channel.empty) {
+                radioSpecLayoutToken++
+                zeroWidthSpecRetries = 0
                 channelFreq.text   = card.context.getString(R.string.empty_channel)
                 channelName.text   = ""
                 channelDuplex.text = ""
@@ -212,10 +223,21 @@ class ChannelAdapter(
 
                 val specItems = buildRadioSpecItems(channel)
                 pendingRadioSpecItems = specItems
+                radioSpecLayoutToken++
+                zeroWidthSpecRetries = 0
+                val layoutToken = radioSpecLayoutToken
+                val boundChannelNumber = channel.number
                 channelDriverRow.visibility =
                     if (specItems.isEmpty()) View.GONE else View.VISIBLE
                 if (specItems.isNotEmpty()) {
-                    channelRadioSpecColumns.post { applyRadioSpecColumns(specItems) }
+                    channelRadioSpecColumns.post {
+                        if (layoutToken != radioSpecLayoutToken) return@post
+                        val pos = bindingAdapterPosition
+                        if (pos == RecyclerView.NO_POSITION) return@post
+                        if (this@ChannelAdapter.getItem(pos).number != boundChannelNumber) return@post
+                        val items = pendingRadioSpecItems ?: return@post
+                        applyRadioSpecColumns(items, layoutToken)
+                    }
                 } else {
                     channelRadioSpecColumns.removeAllViews()
                     lastSpecCols = -1
@@ -282,14 +304,25 @@ class ChannelAdapter(
          * Distributes [items] across weighted vertical columns **column-major**:
          * fill column 0 top→bottom, then column 1 top→bottom, etc.
          */
-        private fun applyRadioSpecColumns(items: List<String>) {
+        private fun applyRadioSpecColumns(items: List<String>, layoutToken: Long) {
+            if (layoutToken != radioSpecLayoutToken) return
             if (items.isEmpty()) return
             val container = channelRadioSpecColumns
             val w = container.width
             if (w <= 0) {
-                container.post { applyRadioSpecColumns(items) }
+                if (zeroWidthSpecRetries < MAX_ZERO_WIDTH_SPEC_RETRIES) {
+                    zeroWidthSpecRetries++
+                    container.post {
+                        if (layoutToken != radioSpecLayoutToken) return@post
+                        applyRadioSpecColumns(items, layoutToken)
+                    }
+                } else {
+                    zeroWidthSpecRetries = 0
+                    scheduleRadioSpecPreDrawOrSingleColumn(items, layoutToken)
+                }
                 return
             }
+            zeroWidthSpecRetries = 0
             val res = card.context.resources
             val minCellPx = res.getDimensionPixelSize(R.dimen.channel_radio_spec_min_cell_width)
             val maxCols = res.getInteger(R.integer.channel_radio_spec_max_columns)
@@ -317,6 +350,46 @@ class ChannelAdapter(
                 }
                 container.addView(col, LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f))
             }
+        }
+
+        /**
+         * After repeated width==0, wait one pre-draw; if still zero, lay out as a single column
+         * so narrow/fold transitions still show content.
+         */
+        private fun scheduleRadioSpecPreDrawOrSingleColumn(items: List<String>, layoutToken: Long) {
+            val container = channelRadioSpecColumns
+            val vto = container.viewTreeObserver
+            if (!vto.isAlive) {
+                applyRadioSpecSingleColumn(items, layoutToken)
+                return
+            }
+            vto.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    container.viewTreeObserver.removeOnPreDrawListener(this)
+                    if (layoutToken != radioSpecLayoutToken) return true
+                    if (container.width > 0) {
+                        applyRadioSpecColumns(items, layoutToken)
+                    } else {
+                        applyRadioSpecSingleColumn(items, layoutToken)
+                    }
+                    return true
+                }
+            })
+        }
+
+        /** One vertical column, full width — used when measured width is still 0. */
+        private fun applyRadioSpecSingleColumn(items: List<String>, layoutToken: Long) {
+            if (layoutToken != radioSpecLayoutToken) return
+            if (items.isEmpty()) return
+            lastSpecCols = 1
+            lastSpecItems = items.toList()
+            val container = channelRadioSpecColumns
+            container.removeAllViews()
+            val col = LinearLayout(card.context).apply {
+                orientation = LinearLayout.VERTICAL
+            }
+            items.forEach { col.addView(newSpecCell(it)) }
+            container.addView(col, LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT, 0f))
         }
 
         private fun newSpecCell(text: CharSequence): TextView {

--- a/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/ChannelEditActivity.kt
+++ b/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/ChannelEditActivity.kt
@@ -544,12 +544,7 @@ class ChannelEditActivity : AppCompatActivity() {
             c.extra = extraParamEditTexts.mapValues { it.value.text?.toString()?.trim() ?: "" }
         }
         // Sync group fields from extra so upload has correct group1–4
-        if (c.extra.isNotEmpty()) {
-            c.group1 = c.extra["Group 1"] ?: c.extra["group1"] ?: c.group1
-            c.group2 = c.extra["Group 2"] ?: c.extra["group2"] ?: c.group2
-            c.group3 = c.extra["Group 3"] ?: c.extra["group3"] ?: c.group3
-            c.group4 = c.extra["Group 4"] ?: c.extra["group4"] ?: c.group4
-        }
+        c.syncGroupsFromExtra()
 
         // Busy Lock — force off when a repeater/split offset is present (radio rule)
         val hasOffset = duplexStr == "+" || duplexStr == "-" ||

--- a/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/radio/Channel.kt
+++ b/AndroidRadioDroid/app/src/main/java/com/radiodroid/app/radio/Channel.kt
@@ -62,6 +62,19 @@ data class Channel(
         else   -> ""
     }
 
+    /**
+     * Copies group letter slots from [extra] into [group1]–[group4].
+     * Drivers (e.g. NICFW H3) store these only under Memory.extra; the main list uses [group1]–[group4].
+     * Key fallbacks match [com.radiodroid.app.ChannelEditActivity] save path.
+     */
+    fun syncGroupsFromExtra() {
+        if (extra.isEmpty()) return
+        group1 = extra["Group 1"] ?: extra["group1"] ?: group1
+        group2 = extra["Group 2"] ?: extra["group2"] ?: group2
+        group3 = extra["Group 3"] ?: extra["group3"] ?: group3
+        group4 = extra["Group 4"] ?: extra["group4"] ?: group4
+    }
+
     companion object {
         /**
          * Construct a Channel from a Python dict returned by chirp_bridge.download().
@@ -97,7 +110,7 @@ data class Channel(
                 rxToneVal       = obj.callAttr("get", "rx_tone_val")?.toDouble(),
                 rxTonePolarity  = obj.callAttr("get", "rx_tone_polarity")?.toString()?.ifEmpty { null },
                 extra           = parseExtraFromPyObject(obj),
-            )
+            ).also { it.syncGroupsFromExtra() }
         }
 
         /** Build a map from Python dict "extra" (Memory.extra). */
@@ -147,7 +160,7 @@ data class Channel(
                 group3          = obj.optString("group3", "None"),
                 group4          = obj.optString("group4", "None"),
                 flagsRaw        = obj.optInt("flags_raw", 0),
-            )
+            ).also { it.syncGroupsFromExtra() }
         }
 
         /** Serialize Channel to JSON for a RadioDroid backup file (all fields). */

--- a/docs/design/channel_card_radio_specific_layout.md
+++ b/docs/design/channel_card_radio_specific_layout.md
@@ -81,3 +81,5 @@ If cells do not fit at the configured minimum width, additional **wrap lines** s
 
 - Long values: use `maxLines` + `ellipsize` on cells.
 - Very many extras: grid grows vertically; acceptable for v1.
+- **RecyclerView:** Deferred `post { … }` layout for the radio-specific block must not run after the row is rebound to another channel (stale closure). Use a per-bind layout token + `bindingAdapterPosition` / channel-number checks before applying columns.
+- **Zero-width passes:** On some fold/narrow layouts the column container can measure `width == 0` briefly; cap blind reposts and fall back to one pre-draw retry or a single-column layout so the block does not stay empty.


### PR DESCRIPTION
## Summary
- **#10:** Add \Channel.syncGroupsFromExtra()\ (same keys as editor) and call from \romPyObject\, \romJson\, and \ChannelEditActivity\ so \group1\–\group4\ match \Memory.extra\ for drivers that only store groups there (e.g. NICFW H3).
- **#11:** Harden \ChannelAdapter\ radio-specific block: per-bind layout token, \indingAdapterPosition\ + channel-number checks before applying columns; cap \width==0\ reposts; one-shot pre-draw retry or single-column fallback.

## Test plan
- [ ] NICFW H3: set groups, confirm main list matches editor; save / reopen.
- [ ] Narrow width / fold: scroll channel list; confirm radio-specific rows stay populated.

\ssembleDebug\ ✅

Made with [Cursor](https://cursor.com)